### PR TITLE
Fix version requirements of torch and transformer

### DIFF
--- a/discrete_speech_metrics/speechbleu.py
+++ b/discrete_speech_metrics/speechbleu.py
@@ -94,8 +94,15 @@ class SpeechBLEU:
             raise ValueError(f"Not found the setting for {model_type}.")
         file_path = pathlib.Path(__file__).parent.absolute()
         km_path = file_path / f"km/km{vocab}.bin"
+        os.makedirs(file_path / "km", exist_ok=True)
         if not vocab in [50, 100, 200]:
             raise ValueError(f"km vocabularies other than 50, 100, 200 are not supported.")
+        if not km_path.exists():
+            url = f"http://sarulab.sakura.ne.jp/saeki/discrete_speech_metrics/km/km{vocab}.bin"
+            subprocess.run(["wget", url, "-O", km_path])
+            print(f"Downloaded file from {url} to {km_path}")
+        else:
+            print(f"Using a cache at {km_path}")
         self.sr = sr
         self.layer = layer
         self.apply_kmeans = ApplyKmeans(km_path, device=self.device)

--- a/discrete_speech_metrics/speechtokendistance.py
+++ b/discrete_speech_metrics/speechtokendistance.py
@@ -91,9 +91,16 @@ class SpeechTokenDistance:
         else:
             raise ValueError(f"Not found the setting for {model_type}.")
         file_path = pathlib.Path(__file__).parent.absolute()
+        km_path = file_path / f"km/km{vocab}.bin"
+        os.makedirs(file_path / "km", exist_ok=True)
         if not vocab in [50, 100, 200]:
             raise ValueError(f"km vocabularies other than 50, 100, 200 are not supported.")
-        km_path = file_path / f"km/km{vocab}.bin"
+        if not km_path.exists():
+            url = f"http://sarulab.sakura.ne.jp/saeki/discrete_speech_metrics/km/km{vocab}.bin"
+            subprocess.run(["wget", url, "-O", km_path])
+            print(f"Downloaded file from {url} to {km_path}")
+        else:
+            print(f"Using a cache at {km_path}")
         self.sr = sr
         self.layer = layer
         self.use_gpu = True

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
         'scipy>=1.7.1',
         'pypesq>=1.2.4',
         'librosa>=0.8.1',
-        'transformers>=4.36.2',
-        'torch>=1.10.1',
-        'torchaudio>=0.10.1',
+        'transformers==4.36.2',         # Setting these due to checkpoint compatibility.
+        'torch>=1.10.1,<=1.13.0',       # https://github.com/huggingface/transformers/issues/26796
+        'torchaudio>=0.10.1,<=0.13.0',  # In torch >= 2.0.0, warnings for checkpoint mismatch are raised.
         'joblib>=1.0.1',
         'nltk>=3.6.5',
         'Levenshtein>=0.23.0',


### PR DESCRIPTION
torch >= 2.0 raised the warning for the checkpoint incompatibility.

Changed the requirements in setup.py to address this issue.
