### PR TITLE
Supporting PyTorch 2.0+ versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
         'scipy>=1.7.1',
         'pypesq>=1.2.4',
         'librosa>=0.8.1',
-        'transformers==4.36.2',         # Setting these due to checkpoint compatibility.
-        'torch>=1.10.1,<=1.13.0',       # https://github.com/huggingface/transformers/issues/26796
-        'torchaudio>=0.10.1,<=0.13.0',  # In torch >= 2.0.0, warnings for checkpoint mismatch are raised.
+        'transformers>=4.36.2',
+        'torch>=1.10.1',       # https://github.com/huggingface/transformers/issues/26796
+        'torchaudio>=0.10.1',  # In torch >= 2.0.0, warnings for checkpoint mismatch are raised.
         'joblib>=1.0.1',
         'nltk>=3.6.5',
         'Levenshtein>=0.23.0',


### PR DESCRIPTION
This PR supports PyTorch 2+.

The following warning for the checkpoint loading is raised with PyTorch2+.
```
Some weights of the model checkpoint at facebook/hubert-base-ls960 were not used when initializing HubertModel: ['encoder.pos_conv_embed.conv.weight_g', 'encoder.pos_conv_embed.conv.weight_v']
- This IS expected if you are initializing HubertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing HubertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Some weights of HubertModel were not initialized from the model checkpoint at facebook/hubert-base-ls960 and are newly initialized: ['encoder.pos_conv_embed.conv.parametrizations.weight.original0', 'encoder.pos_conv_embed.conv.parametrizations.weight.original1']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
```

However, according to the following discussions, this error should be a false alarm. So I decided to support the PyTorch 2.0+ versions for the usability.
https://shorturl.at/xGHL8
https://shorturl.at/gqtBW
https://shorturl.at/ouJVX



